### PR TITLE
Fixed invalid resource reference error

### DIFF
--- a/kds-testdata/input/fsh/modul-molgen/Anforderung.fsh
+++ b/kds-testdata/input/fsh/modul-molgen/Anforderung.fsh
@@ -14,5 +14,5 @@ Usage: #example
 * authoredOn = "2022-04-07"
 * reasonCode = $sct#447886005 "Adenocarcinoma of anorectum (disorder)"
 * specimen = Reference(mii-exa-test-data-patient-3-specimen-1)
-* supportingInfo[familienanamnese] = Reference(mii-exa-molgen-family-member-history-1)
+* supportingInfo[familienanamnese] = Reference(mii-exa-test-data-patient-3-molgen-family-member-history-1)
 


### PR DESCRIPTION
Fixes the following referential integrity error that appears when the testdata-Bundle is posted to a server that is not pre-loaded with the examples from KDS-packages:

```json
{
    "resourceType": "OperationOutcome",
    "issue": [
        {
            "severity": "error",
            "code": "processing",
            "diagnostics": "HAPI-0505: Invalid resource reference found at path[ServiceRequest.supportingInfo] - Does not contain resource type - mii-exa-molgen-family-member-history-1"
        }
    ]
}
```